### PR TITLE
CSE.BL project target framework update to .NET Core 3.1

### DIFF
--- a/CSE.BL/CSE.BL.csproj
+++ b/CSE.BL/CSE.BL.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
CSE.BL project target framework was inconsistent. Therefore it has been updated to .NET Core 3.1
@kkersis 